### PR TITLE
fix build error with c++ 11 and catkin depend warning

### DIFF
--- a/gazebo_grasp_plugin/CMakeLists.txt
+++ b/gazebo_grasp_plugin/CMakeLists.txt
@@ -31,12 +31,23 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES gazebo_grasp_fix
   CATKIN_DEPENDS gazebo_ros geometry_msgs roscpp std_msgs
-  DEPENDS gazebo 
+  DEPENDS gazebo_ros
 )
 
 ###########
 ## Build ##
 ###########
+# check c++11 / c++0x
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "-std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "-std=c++0x")
+else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
+endif()
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations

--- a/gazebo_state_plugins/CMakeLists.txt
+++ b/gazebo_state_plugins/CMakeLists.txt
@@ -40,12 +40,23 @@ catkin_package(
   LIBRARIES gazebo_state_plugins gazebo_map_publisher
   CATKIN_DEPENDS geometry_msgs roscpp shape_msgs std_msgs nav_msgs gazebo_world_plugin_loader
         gazebo_ros object_msgs object_msgs_tools eigen_conversions
-  DEPENDS gazebo
+  DEPENDS gazebo_ros
 )
 
 ###########
 ## Build ##
 ###########
+# check c++11 / c++0x
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "-std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "-std=c++0x")
+else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
+endif()
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations

--- a/gazebo_test_tools/CMakeLists.txt
+++ b/gazebo_test_tools/CMakeLists.txt
@@ -64,7 +64,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES gazebo_test_tools
   CATKIN_DEPENDS object_msgs gazebo_ros geometry_msgs roscpp std_msgs message_runtime
-  DEPENDS gazebo 
+  DEPENDS gazebo_ros
 )
 
 ###########

--- a/gazebo_world_plugin_loader/CMakeLists.txt
+++ b/gazebo_world_plugin_loader/CMakeLists.txt
@@ -5,7 +5,7 @@ project(gazebo_world_plugin_loader)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(
-  catkin 
+  catkin
   REQUIRED COMPONENTS
   roscpp
   gazebo_ros
@@ -31,12 +31,24 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES gazebo_world_plugin_loader
   CATKIN_DEPENDS roscpp gazebo_ros
-  DEPENDS gazebo 
+  DEPENDS gazebo_ros
 )
 
 ###########
 ## Build ##
 ###########
+# check c++11 / c++0x
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "-std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "-std=c++0x")
+else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
+endif()
+
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations


### PR DESCRIPTION
This make the compile process directly without set c++11 compiler flag manually.