### PR TITLE
Added ContactManager filter release instruction for safe plugin reloa…

### DIFF
--- a/gazebo_grasp_plugin/include/gazebo_grasp_plugin/GazeboGraspFix.h
+++ b/gazebo_grasp_plugin/include/gazebo_grasp_plugin/GazeboGraspFix.h
@@ -249,6 +249,9 @@ class GazeboGraspFix : public ModelPlugin
 
     //last time OnUpdate() was called
     common::Time prevUpdateTime;
+
+    //ContactManager filter to be removed in destructor
+    std::string filter_name;
 };
 
 }

--- a/gazebo_grasp_plugin/src/GazeboGraspFix.cpp
+++ b/gazebo_grasp_plugin/src/GazeboGraspFix.cpp
@@ -37,11 +37,12 @@ GazeboGraspFix::GazeboGraspFix(physics::ModelPtr _model)
 GazeboGraspFix::~GazeboGraspFix()
 {
   // Release filter to make it safe to reload the model with plugin
-  if (!filter_name.empty())
+  if (!filter_name.empty() && this->world)
   {
     physics::PhysicsEnginePtr physics = GetPhysics(this->world);
     physics::ContactManager *contactManager = physics->GetContactManager();
-    contactManager->RemoveFilter(filter_name);
+    if (contactManager)
+        contactManager->RemoveFilter(filter_name);
   }
   this->update_connection.reset();
   if (this->node) this->node->Fini();

--- a/gazebo_grasp_plugin/src/GazeboGraspFix.cpp
+++ b/gazebo_grasp_plugin/src/GazeboGraspFix.cpp
@@ -36,6 +36,13 @@ GazeboGraspFix::GazeboGraspFix(physics::ModelPtr _model)
 ////////////////////////////////////////////////////////////////////////////////
 GazeboGraspFix::~GazeboGraspFix()
 {
+  // Release filter to make it safe to reload the model with plugin
+  if (!filter_name.empty())
+  {
+    physics::PhysicsEnginePtr physics = GetPhysics(this->world);
+    physics::ContactManager *contactManager = physics->GetContactManager();
+    contactManager->RemoveFilter(filter_name);
+  }
   this->update_connection.reset();
   if (this->node) this->node->Fini();
   this->node.reset();
@@ -261,7 +268,8 @@ void GazeboGraspFix::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
   physics::ContactManager *contactManager = physics->GetContactManager();
   contactManager->PublishContacts();  // TODO not sure this is required?
 
-  std::string topic = contactManager->CreateFilter(model->GetScopedName(),
+  filter_name = model->GetScopedName();
+  std::string topic = contactManager->CreateFilter(filter_name,
                       collisionNames);
   if (!this->contactSub)
   {


### PR DESCRIPTION
I have found that I can't spawn/delete same model multiple times with GrastFix plugin is loaded. After model deletion, I am trying to load it again, but having an error message:
```
[Err] [ContactManager.cc:360] Filter with the same name already exists! Aborting
```

This PR introduces a fix that will make plugin remove the ContactManager filter in destructor allowing us to spawn same model again.