### PR TITLE
Replace ignition::math::Box with ignition::math::AxisAlignedBox for Gazebo 11+

### DIFF
--- a/gazebo_state_plugins/src/GazeboObjectInfo.cpp
+++ b/gazebo_state_plugins/src/GazeboObjectInfo.cpp
@@ -157,7 +157,7 @@ shape_msgs::SolidPrimitive * GazeboObjectInfo::getSolidPrimitive(physics::Collis
     else
     {
         ROS_WARN("shape type %i of collision %s not supported. Using bounding box instead. ", c->GetShapeType(),c->GetName().c_str());
-        gz_math::Box box = GetBoundingBox(*c);
+        GzBox box = GetBoundingBox(*c);
         GzVector3 bb = GetBoundingBoxDimensions(box);
         if ((GetX(bb) < 1e-05) || (GetY(bb) < 1e-05) || (GetZ(bb) < 1e-05)){
             ROS_WARN_ONCE("Skipping coll %s because its bounding box is flat",c->GetName().c_str());

--- a/gazebo_version_helpers/include/gazebo_version_helpers/GazeboVersionHelpers.h
+++ b/gazebo_version_helpers/include/gazebo_version_helpers/GazeboVersionHelpers.h
@@ -9,6 +9,11 @@ namespace gazebo
 // typedefs
 #if GAZEBO_MAJOR_VERSION >= 8
 namespace gz_math = ignition::math;
+    #if GAZEBO_MAJOR_VERSION >= 11
+    typedef gz_math::AxisAlignedBox GzBox;
+    #else
+    typedef gz_math::Box GzBox;
+    #endif
 typedef gz_math::Pose3d GzPose3;
 typedef gz_math::Vector3d GzVector3;
 typedef gz_math::Quaterniond GzQuaternion;
@@ -16,12 +21,14 @@ typedef gz_math::Matrix4d GzMatrix4;
 typedef gz_math::Matrix3d GzMatrix3;
 #else
 namespace gz_math = gazebo::math;
+typedef gz_math::Box GzBox;
 typedef gz_math::Pose GzPose3;
 typedef gz_math::Vector3 GzVector3;
 typedef gz_math::Quaternion GzQuaternion;
 typedef gz_math::Matrix4 GzMatrix4;
 typedef gz_math::Matrix3 GzMatrix3;
 #endif
+
 
 // Helper functions
 // //////////////////////////
@@ -116,7 +123,7 @@ std::string GetName(const T& t)
 
 ///////////////////////////////////////////////////////////////////////////////
 template<typename T>
-gz_math::Box GetBoundingBox(const T &t)
+GzBox GetBoundingBox(const T &t)
 {
 #if GAZEBO_MAJOR_VERSION >= 8
     return t.BoundingBox();
@@ -126,7 +133,7 @@ gz_math::Box GetBoundingBox(const T &t)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-GzVector3 GetBoundingBoxDimensions(const gz_math::Box &box);
+GzVector3 GetBoundingBoxDimensions(const GzBox &box);
 
 ///////////////////////////////////////////////////////////////////////////////
 template<typename T>

--- a/gazebo_version_helpers/src/GazeboVersionHelpers.cpp
+++ b/gazebo_version_helpers/src/GazeboVersionHelpers.cpp
@@ -314,7 +314,7 @@ gazebo::physics::Model_V gazebo::GetModels(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-gazebo::GzVector3 gazebo::GetBoundingBoxDimensions(const gz_math::Box &box)
+gazebo::GzVector3 gazebo::GetBoundingBoxDimensions(const GzBox &box)
 {
 #if GAZEBO_MAJOR_VERSION >= 8
     GzVector3 bb(box.XLength(), box.YLength(), box.ZLength());


### PR DESCRIPTION
See here for deprecations from 10->11:
https://github.com/osrf/gazebo/blob/gazebo11/Migration.md#modifications

tested (compilation) on 
* Ubuntu 20.04/Gazebo 11/ROS noetic
* Ubuntu 16.04/Gazebo 7/ROS kinetic