### PR TITLE
Publish grasp events on a latched topic (implements #36)

### DIFF
--- a/gazebo_grasp_plugin/CMakeLists.txt
+++ b/gazebo_grasp_plugin/CMakeLists.txt
@@ -29,11 +29,18 @@ find_package(gazebo REQUIRED)
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES gazebo_grasp_fix
+  # Binary directory required for proto headers inclusion to work, because install commands don't
+  # get executed in devel space. The directory above is required so that an include of
+  # <gazebo_grasp_plugin/msgs/grasp_event.pb.h> 
+  # also works in devel space like it needs to be in install space.
+  # Probably we can find a better solution for this, but until then this
+  # fix will be OK.
+  INCLUDE_DIRS include ${CMAKE_CURRENT_BINARY_DIR}/..
+  LIBRARIES gazebo_grasp_fix gazebo_grasp_msgs
   CATKIN_DEPENDS gazebo_ros geometry_msgs roscpp std_msgs gazebo_version_helpers
   DEPENDS gazebo
 )
+
 
 ###########
 ## Build ##
@@ -57,11 +64,14 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+add_subdirectory(msgs)
 link_directories(
   ${catkin_LIBRARY_DIRS}
   ${GAZEBO_LIBRARY_DIRS}
+  ${CMAKE_CURRENT_BINARY_DIR}/msgs
 )
 
 ## Declare a cpp library
@@ -74,10 +84,11 @@ add_dependencies(gazebo_grasp_fix ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 
-target_link_libraries(gazebo_grasp_fix 
-	${catkin_LIBRARIES} 
-	${GAZEBO_LIBRARIES} 
-	${Boost_LIBRARIES}
+target_link_libraries(gazebo_grasp_fix
+   gazebo_grasp_msgs
+   ${catkin_LIBRARIES}
+   ${GAZEBO_LIBRARIES}
+   ${Boost_LIBRARIES}
 )
 
 #############

--- a/gazebo_grasp_plugin/include/gazebo_grasp_plugin/GazeboGraspFix.h
+++ b/gazebo_grasp_plugin/include/gazebo_grasp_plugin/GazeboGraspFix.h
@@ -95,19 +95,20 @@ class GazeboGraspFix : public ModelPlugin
     GazeboGraspFix();
     GazeboGraspFix(physics::ModelPtr _model);
     virtual ~GazeboGraspFix();
+  
+  private:
 
     /**
      * Gets called just after the object has been attached to the palm link on \e armName
      */
-    virtual void OnAttach(const std::string &objectName,
-                          const std::string &armName) {}
+    void OnAttach(const std::string &objectName,
+                          const std::string &armName);
     /**
      * Gets called just after the object has been detached to the palm link on \e armName
      */
-    virtual void OnDetach(const std::string &objectName,
-                          const std::string &armName) {}
+    void OnDetach(const std::string &objectName,
+                          const std::string &armName);
 
-  private:
     virtual void Init();
     virtual void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
     /**
@@ -189,10 +190,11 @@ class GazeboGraspFix : public ModelPlugin
 
     event::ConnectionPtr update_connection;
     transport::NodePtr node;
-    transport::SubscriberPtr contactSub; //subscriber to contact updates
+    transport::PublisherPtr eventsPub;   // publisher of grasping events
+    transport::SubscriberPtr contactSub; // subscriber to contact updates
 
     // tolerance (in degrees) between force vectors to
-    // beconsidered "opposing"
+    // be considered "opposing"
     float forcesAngleTolerance;
 
     // when an object is attached, collisions with it may be disabled, in case the

--- a/gazebo_grasp_plugin/msgs/CMakeLists.txt
+++ b/gazebo_grasp_plugin/msgs/CMakeLists.txt
@@ -1,0 +1,20 @@
+find_package(Protobuf REQUIRED)
+
+set(msgs
+ grasp_event.proto
+)
+PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${msgs})
+add_library(gazebo_grasp_msgs SHARED ${PROTO_SRCS})
+target_link_libraries(gazebo_grasp_msgs ${PROTOBUF_LIBRARY})
+
+## Mark executables and/or libraries for installation
+install(TARGETS gazebo_grasp_msgs
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} 
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.pb.h"
+)

--- a/gazebo_grasp_plugin/msgs/grasp_event.proto
+++ b/gazebo_grasp_plugin/msgs/grasp_event.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+package gazebo.msgs;
+
+/// \ingroup gazebo_msgs
+/// \interface GraspEvent
+/// \brief Message to notify about grasp events
+message GraspEvent
+{
+  // name of grasping arm/gripper
+  required string arm = 1;
+  
+  // collision shape name of grasped object
+  required string object = 2;
+  
+  // detached if false
+  required bool attached = 3;
+}

--- a/gazebo_grasp_plugin_ros/CMakeLists.txt
+++ b/gazebo_grasp_plugin_ros/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(gazebo_grasp_plugin_ros)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  gazebo_grasp_plugin
+  message_generation
+  roscpp
+)
+
+find_package(gazebo REQUIRED)
+
+################################################
+## Messages
+################################################
+
+add_message_files(
+  FILES GazeboGraspEvent.msg
+)
+
+generate_messages(
+  DEPENDENCIES std_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES gazebo_grasp_plugin_ros
+ CATKIN_DEPENDS gazebo_grasp_plugin message_runtime roscpp
+ DEPENDS gazebo
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+)
+link_directories(
+  ${catkin_LIBRARY_DIRS}
+  ${GAZEBO_LIBRARY_DIRS}
+)
+
+## Declare a C++ executable
+add_executable(${PROJECT_NAME}_republisher_node src/grasp_event_republisher.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_republisher_node"
+set_target_properties(${PROJECT_NAME}_republisher_node PROPERTIES OUTPUT_NAME grasp_event_republisher PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+add_dependencies(${PROJECT_NAME}_republisher_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_republisher_node gazebo_grasp_plugin_ros_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}_republisher_node
+  ${catkin_LIBRARIES}
+  ${GAZEBO_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+## Mark executables for installation
+install(TARGETS ${PROJECT_NAME}_republisher_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/gazebo_grasp_plugin_ros/README.md
+++ b/gazebo_grasp_plugin_ros/README.md
@@ -1,0 +1,13 @@
+gazebo_grasp_plugin_ros
+-----------------------
+
+ROS-specific components for `gazebo_grasp_plugin`.
+
+This package contains a re-publisher for the grasp event message published by
+the gazebo grasp plugin.
+
+To run the node, after starting up your robot with the gazebo grasp plugin loaded:
+
+rosrun gazebo_grasp_plugin_ros grasp_event_republisher
+
+The topic will be published on "<node-name>/grasp_event".

--- a/gazebo_grasp_plugin_ros/msg/GazeboGraspEvent.msg
+++ b/gazebo_grasp_plugin_ros/msg/GazeboGraspEvent.msg
@@ -1,0 +1,10 @@
+# Message to notify about grasp events in gazebo
+
+# name of grasping arm/gripper 
+string arm
+
+# collision shape name of grasped object
+string object
+
+# detached if false
+bool attached

--- a/gazebo_grasp_plugin_ros/package.xml
+++ b/gazebo_grasp_plugin_ros/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>gazebo_grasp_plugin_ros</name>
+  <version>0.0.1</version>
+  <description>The gazebo_grasp_plugin_ros package</description>
+
+  <maintainer email="jennifer.e.buehler@gmail.com">Jennifer Buehler</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">https://github.com/JenniferBuehler/gazebo-pkgs</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <depend>gazebo_grasp_plugin</depend>
+  <depend>roscpp</depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+  </export>
+</package>

--- a/gazebo_grasp_plugin_ros/src/grasp_event_republisher.cpp
+++ b/gazebo_grasp_plugin_ros/src/grasp_event_republisher.cpp
@@ -1,0 +1,58 @@
+#include <gazebo/transport/transport.hh>
+
+#include <gazebo_grasp_plugin/msgs/grasp_event.pb.h>
+#include <gazebo_grasp_plugin_ros/GazeboGraspEvent.h>
+#include <ros/ros.h>
+
+using GraspEventPtr = boost::shared_ptr<const gazebo::msgs::GraspEvent>;
+
+ros::Publisher gGraspEventPublisher;
+
+/**
+ * Callback to receive gazebo grasp event messages
+ */
+void ReceiveGraspMsg(const GraspEventPtr& gzMsg)
+{
+  ROS_INFO_STREAM("Re-publishing grasp event: " << gzMsg->DebugString());
+  gazebo_grasp_plugin_ros::GazeboGraspEvent rosMsg;
+  rosMsg.arm      = gzMsg->arm();
+  rosMsg.object   = gzMsg->object();
+  rosMsg.attached = gzMsg->attached();
+  gGraspEventPublisher.publish(rosMsg);
+}
+
+int main(int argc, char** argv)
+{
+  // Initialize ROS and Gazebo transport
+  ros::init(argc, argv, "gazebo_grasp_plugin_event_republisher");
+  if (!gazebo::transport::init())
+  {
+    ROS_ERROR("Unable to initialize gazebo transport - is gazebo running?");
+    return 1;
+  }
+  gazebo::transport::run();
+
+  // Subscribe to Gazebo grasp event message
+  gazebo::transport::NodePtr gzNode(new gazebo::transport::Node());
+  gzNode->Init();
+  gazebo::transport::SubscriberPtr subscriber;
+  try
+  {
+    subscriber = gzNode->Subscribe("~/grasp_events", &ReceiveGraspMsg);
+  }
+  catch (std::exception e)
+  {
+    ROS_ERROR_STREAM("Error subscribing to topic: " << e.what());
+    return 1;
+  }
+
+  // Initialize ROS publisher
+  ros::NodeHandle   rosNode("~");
+  const std::string pubTopic = "grasp_events";
+  gGraspEventPublisher =
+    rosNode.advertise<gazebo_grasp_plugin_ros::GazeboGraspEvent>(pubTopic, 1);
+
+  ros::spin();
+  gazebo::transport::fini();
+  return 0;
+}


### PR DESCRIPTION
This allows to emulate a physical grasped/no-grasped check, as described on #36